### PR TITLE
[FIX] DomGraph UI 개선

### DIFF
--- a/src/app/result/components/DomGraph.tsx
+++ b/src/app/result/components/DomGraph.tsx
@@ -89,7 +89,15 @@ export default function DomGraph({ data }: DomGraphProps) {
     const nodes = rootRef.current.descendants();
     const links = rootRef.current.links();
 
-    nodes.forEach((d) => (d.y = d.depth * 180));
+    const treeLayout = d3.tree<DomNode>().nodeSize([80, 30]);
+    treeLayout(rootRef.current);
+
+    rootRef.current.descendants().forEach((d) => {
+      d.y = d.depth * 180; 
+    });
+
+    updateSvgWidth(); 
+    updateSvgHeight();
 
     const nodeSelection = g.selectAll<SVGGElement, d3.HierarchyPointNode<DomNode>>('g.node');
     const linkSelection = g.selectAll<SVGPathElement, d3.HierarchyPointLink<DomNode>>('path.link');

--- a/src/app/result/components/DomGraph.tsx
+++ b/src/app/result/components/DomGraph.tsx
@@ -112,21 +112,30 @@ export default function DomGraph({ data }: DomGraphProps) {
         update(d, g);
       });
 
+    const nodeWidth = 80;
+    const nodeHeight = 30;
+
     nodeEnter
-      .append('circle')
-      .attr('r', 10)
-      .style('fill', (d) => (d._children ? 'lightsteelblue' : '#32CD32'))
+      .append('rect')
+      .attr('width', nodeWidth)
+      .attr('height', nodeHeight)
+      .attr('x', -nodeWidth / 2)
+      .attr('y', -nodeHeight / 2)
+      .style('fill', '#32CD32')
       .style('stroke', '#000')
-      .style('stroke-width', 2);
+      .style('stroke-width', 2)
+      .style('rx', 5)
+
 
     nodeEnter
       .append('text')
       .attr('dy', '.35em')
-      .attr('x', (d) => (d.children || d._children ? -13 : 13))
-      .attr('text-anchor', (d) => (d.children || d._children ? 'end' : 'start'))
+      .attr('x', 0)
+      .attr('y', 0)
+      .attr('text-anchor', 'middle')
       .text((d) => d.data.tag)
       .style('fill', '#1E90FF')
-      .style('font-weight', 'bold');
+      .style('font-weight', 'bold')
 
     const nodeUpdate = nodeEnter.merge(node);
 

--- a/src/app/result/components/DomGraph.tsx
+++ b/src/app/result/components/DomGraph.tsx
@@ -39,6 +39,10 @@ export default function DomGraph({ data }: DomGraphProps) {
     renderTree(root);
   }, [data]);
 
+  /**
+   * 루트 노드의 직계 자식까지만 보이도록 설정하는 함수  
+   * (하위 노드는 `_children`으로 저장하고 기본적으로 접힘)
+   */
   const collapseChildren = (root: d3.HierarchyPointNode<DomNode>) => {
     root.children?.forEach((child) => {
       child._children = child.children;
@@ -46,22 +50,39 @@ export default function DomGraph({ data }: DomGraphProps) {
     });
   };
 
+  /**
+   * 노드의 깊이를 기준으로 Y 좌표를 설정하는 함수  
+   * (노드 간 Y 간격을 180으로 설정)
+   */
   const adjustNodePositions = (root: d3.HierarchyPointNode<DomNode>) => {
     root.descendants().forEach((d) => {
       d.y = d.depth * 180;
     });
   };
 
+  /**
+   * 트리의 최대 깊이 및 X 좌표를 계산하여 SVG 크기를 동적으로 조정하는 함수  
+   */
   const updateSvgSize = () => {
     if (!rootRef.current) return;
+
     const maxDepth = d3.max(rootRef.current.descendants(), (d) => d.depth) || 0;
     setSvgHeight((maxDepth + 1) * 180 + 200);
+
     const maxX = d3.max(rootRef.current.descendants(), (d) => d.x) || 1000;
     setSvgWidth(Math.max(maxX, 1200));
   };
 
+  /**
+   * 트리 구조를 SVG에 렌더링하는 함수  
+   * - 기존 SVG 내용을 초기화  
+   * - SVG 그룹 요소를 생성하고 초기 위치를 설정  
+   * - 줌(zoom) 기능 적용  
+   * - `update` 함수를 호출하여 트리 업데이트  
+   */
   const renderTree = (root: d3.HierarchyPointNode<DomNode>) => {
-    const svg = d3.select(svgRef.current as SVGSVGElement);
+    if (!svgRef.current) return;
+    const svg = d3.select(svgRef.current);
     svg.selectAll('*').remove();
 
     const initialX = svgWidth / 2;
@@ -69,12 +90,19 @@ export default function DomGraph({ data }: DomGraphProps) {
     const g = svg.append('g').attr('transform', `translate(${initialX}, ${initialY})`);
     gRef.current = g.node()!;
 
-
     applyZoom(svg, g);
     update(root, g);
   };
 
-  const applyZoom = (svg: d3.Selection<SVGSVGElement, unknown, null, undefined>, g: d3.Selection<SVGGElement, unknown, null, undefined>) => {
+  /**
+   * 줌(zoom) 기능을 적용하는 함수  
+   * - 마우스 스크롤로 확대/축소 가능  
+   * - 드래그를 통해 트리 이동 가능  
+   */
+  const applyZoom = (
+    svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
+    g: d3.Selection<SVGGElement, unknown, null, undefined>
+  ) => {
     const zoom = d3.zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.1, 3])
       .on('zoom', (event) => {
@@ -85,6 +113,11 @@ export default function DomGraph({ data }: DomGraphProps) {
     svg.call(zoom.transform, d3.zoomIdentity.translate(svgWidth / 2, 50).scale(1));
   };
 
+  /**
+   * 트리를 업데이트하는 함수  
+   * - 트리 레이아웃을 다시 계산하여 노드 위치 조정  
+   * - 노드와 링크를 업데이트하여 화면에 반영  
+   */
   const update = (source: d3.HierarchyPointNode<DomNode>, g: d3.Selection<SVGGElement, unknown, null, undefined>) => {
     if (!rootRef.current) return;
 
@@ -103,6 +136,11 @@ export default function DomGraph({ data }: DomGraphProps) {
     updateLinks(source, g, links, linkSelection);
   };
 
+  /**
+   * 노드를 업데이트하는 함수  
+   * - 노드를 클릭하면 접고 펼치는 기능 추가  
+   * - 새 노드가 추가될 경우 애니메이션 적용  
+   */
   const updateNodes = (
     source: d3.HierarchyPointNode<DomNode>,
     g: d3.Selection<SVGGElement, unknown, null, undefined>,
@@ -148,6 +186,12 @@ export default function DomGraph({ data }: DomGraphProps) {
       .remove();
   };
 
+  /**
+ * 링크(노드 간 연결선)를 업데이트하는 함수  
+ * - 부모-자식 노드 간 곡선형 링크 생성  
+ * - 새 링크 추가 시 애니메이션 적용  
+ * - 삭제된 링크에 대한 애니메이션 적용  
+ */
   const updateLinks = (
     source: d3.HierarchyPointNode<DomNode>,
     g: d3.Selection<SVGGElement, unknown, null, undefined>,
@@ -155,6 +199,7 @@ export default function DomGraph({ data }: DomGraphProps) {
     linkSelection: d3.Selection<SVGPathElement, d3.HierarchyPointLink<DomNode>, SVGGElement, unknown>
   ) => {
     const link = linkSelection.data(links, (d) => d.target.data.id);
+
     const linkEnter = link.enter()
       .append('path')
       .attr('class', 'link')
@@ -173,12 +218,16 @@ export default function DomGraph({ data }: DomGraphProps) {
       .remove();
   };
 
+  /**
+   * 부모-자식 노드를 연결하는 곡선형 베지어 커브를 생성하는 함수  
+   * - 부모 노드의 아랫부분에서 시작하여 자식 노드의 윗부분으로 연결  
+   */
   const diagonal = (s: { x: number; y: number }, d: { x: number; y: number }) => `
-    M ${s.x} ${s.y + 15}
-    C ${(s.x + d.x) / 2} ${s.y + 15},
-      ${(s.x + d.x) / 2} ${d.y - 15},
-      ${d.x} ${d.y - 15}
-  `;
+  M ${s.x} ${s.y + 15}
+  C ${(s.x + d.x) / 2} ${s.y + 15},
+    ${(s.x + d.x) / 2} ${d.y - 15},
+    ${d.x} ${d.y - 15}
+`;
 
   return (
     <div>

--- a/src/app/result/components/DomGraph.tsx
+++ b/src/app/result/components/DomGraph.tsx
@@ -184,12 +184,23 @@ export default function DomGraph({ data }: DomGraphProps) {
     });
   };
 
-  const diagonal = (s: { x: number; y: number }, d: { x: number; y: number }) => `
-    M ${s.x} ${s.y}
-    C ${(s.x + d.x) / 2} ${s.y},
-      ${(s.x + d.x) / 2} ${d.y},
-      ${d.x} ${d.y}
-  `;
+  const diagonal = (s: { x: number; y: number }, d: { x: number; y: number }) => {
+    const nodeHeight = 30;
+
+    const startX = s.x;
+    const startY = s.y + nodeHeight / 2;
+
+    const endX = d.x;
+    const endY = d.y - nodeHeight / 2;
+
+    return `
+      M ${startX} ${startY}
+      C ${(startX + endX) / 2} ${startY},
+        ${(startX + endX) / 2} ${endY},
+        ${endX} ${endY}
+    `;
+  };
+
 
   return (
     <div>

--- a/src/app/result/components/DomGraph.tsx
+++ b/src/app/result/components/DomGraph.tsx
@@ -19,7 +19,8 @@ type DomGraphProps = {
 export default function DomGraph({ data }: DomGraphProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const gRef = useRef<SVGGElement>(null);
-  const rootRef = useRef<d3.HierarchyPointNode<DomNode>>(null);
+  const rootRef = useRef<d3.HierarchyPointNode<DomNode> | null>(null);
+
   const [svgWidth, setSvgWidth] = useState(1000);
   const [svgHeight, setSvgHeight] = useState(1000);
 
@@ -27,188 +28,157 @@ export default function DomGraph({ data }: DomGraphProps) {
     if (!svgRef.current || !data) return;
 
     const treeLayout = d3.tree<DomNode>().nodeSize([80, 30]);
-
     const root = d3.hierarchy(data) as d3.HierarchyPointNode<DomNode>;
     rootRef.current = root;
 
+    collapseChildren(root);
+    treeLayout(root);
+    adjustNodePositions(root);
+
+    updateSvgSize();
+    renderTree(root);
+  }, [data]);
+
+  const collapseChildren = (root: d3.HierarchyPointNode<DomNode>) => {
     root.children?.forEach((child) => {
       child._children = child.children;
       child.children = undefined;
     });
+  };
 
-    treeLayout(root);
-
+  const adjustNodePositions = (root: d3.HierarchyPointNode<DomNode>) => {
     root.descendants().forEach((d) => {
       d.y = d.depth * 180;
     });
-
-    updateSvgWidth();
-    updateSvgHeight();
-
-    const svg = d3.select(svgRef.current);
-    svg.selectAll('*').remove();
-
-
-    const initialX = svgWidth / 2;
-    const initialY = 50;
-
-    const g = svg.append('g').attr('transform', `translate(${initialX}, ${initialY})`);
-    gRef.current = g.node()!;
-
-    const zoom = d3.zoom<SVGSVGElement, unknown>()
-      .scaleExtent([0.1, 3])
-      .on('zoom', (event) => {
-        d3.select(gRef.current).attr('transform', event.transform.toString());
-      });
-
-    svg.call(zoom);
-    svg.call(zoom.transform, d3.zoomIdentity.translate(initialX, initialY).scale(1));
-
-    update(root, g);
-  }, [data]);
-
-  const updateSvgHeight = () => {
-    if (!rootRef.current) return;
-    const maxDepth = d3.max(rootRef.current.descendants(), (d) => d.depth) || 0;
-    setSvgHeight((maxDepth + 1) * 180 + 200); // Y 간격(180) * 최대 깊이 + 여백
   };
 
-
-  const updateSvgWidth = () => {
+  const updateSvgSize = () => {
     if (!rootRef.current) return;
-    const maxX = d3.max(rootRef.current.descendants(), d => d.x) || 1000;
+    const maxDepth = d3.max(rootRef.current.descendants(), (d) => d.depth) || 0;
+    setSvgHeight((maxDepth + 1) * 180 + 200);
+    const maxX = d3.max(rootRef.current.descendants(), (d) => d.x) || 1000;
     setSvgWidth(Math.max(maxX, 1200));
   };
 
-  const update = (
-    source: d3.HierarchyPointNode<DomNode>,
-    g: d3.Selection<SVGGElement, unknown, null, undefined>
-  ) => {
+  const renderTree = (root: d3.HierarchyPointNode<DomNode>) => {
+    const svg = d3.select(svgRef.current as SVGSVGElement);
+    svg.selectAll('*').remove();
+
+    const initialX = svgWidth / 2;
+    const initialY = 50;
+    const g = svg.append('g').attr('transform', `translate(${initialX}, ${initialY})`);
+    gRef.current = g.node()!;
+
+
+    applyZoom(svg, g);
+    update(root, g);
+  };
+
+  const applyZoom = (svg: d3.Selection<SVGSVGElement, unknown, null, undefined>, g: d3.Selection<SVGGElement, unknown, null, undefined>) => {
+    const zoom = d3.zoom<SVGSVGElement, unknown>()
+      .scaleExtent([0.1, 3])
+      .on('zoom', (event) => {
+        g.attr('transform', event.transform.toString());
+      });
+
+    svg.call(zoom);
+    svg.call(zoom.transform, d3.zoomIdentity.translate(svgWidth / 2, 50).scale(1));
+  };
+
+  const update = (source: d3.HierarchyPointNode<DomNode>, g: d3.Selection<SVGGElement, unknown, null, undefined>) => {
     if (!rootRef.current) return;
+
+    const treeLayout = d3.tree<DomNode>().nodeSize([80, 30]);
+    treeLayout(rootRef.current);
+    adjustNodePositions(rootRef.current);
+    updateSvgSize();
 
     const nodes = rootRef.current.descendants();
     const links = rootRef.current.links();
 
-    const treeLayout = d3.tree<DomNode>().nodeSize([80, 30]);
-    treeLayout(rootRef.current);
-
-    rootRef.current.descendants().forEach((d) => {
-      d.y = d.depth * 180; 
-    });
-
-    updateSvgWidth(); 
-    updateSvgHeight();
-
     const nodeSelection = g.selectAll<SVGGElement, d3.HierarchyPointNode<DomNode>>('g.node');
     const linkSelection = g.selectAll<SVGPathElement, d3.HierarchyPointLink<DomNode>>('path.link');
 
-    const node = nodeSelection.data(nodes, (d) => d.data.id);
+    updateNodes(source, g, nodes, nodeSelection);
+    updateLinks(source, g, links, linkSelection);
+  };
 
-    const nodeEnter = node
-      .enter()
+  const updateNodes = (
+    source: d3.HierarchyPointNode<DomNode>,
+    g: d3.Selection<SVGGElement, unknown, null, undefined>,
+    nodes: d3.HierarchyPointNode<DomNode>[],
+    nodeSelection: d3.Selection<SVGGElement, d3.HierarchyPointNode<DomNode>, SVGGElement, unknown>
+  ) => {
+    const node = nodeSelection.data(nodes, (d) => d.data.id);
+    const nodeEnter = node.enter()
       .append('g')
       .attr('class', 'node')
       .attr('transform', () => `translate(${source.x0 ?? source.x},${source.y0 ?? source.y})`)
       .on('click', (_, d) => {
-        if (d.children) {
-          d._children = d.children;
-          d.children = undefined;
-        } else {
-          d.children = d._children;
-          d._children = undefined;
-        }
+        d.children = d.children ? undefined : d._children;
         update(d, g);
       });
 
-    const nodeWidth = 80;
-    const nodeHeight = 30;
-
-    nodeEnter
-      .append('rect')
-      .attr('width', nodeWidth)
-      .attr('height', nodeHeight)
-      .attr('x', -nodeWidth / 2)
-      .attr('y', -nodeHeight / 2)
+    nodeEnter.append('rect')
+      .attr('width', 80)
+      .attr('height', 30)
+      .attr('x', -40)
+      .attr('y', -15)
       .style('fill', '#32CD32')
       .style('stroke', '#000')
       .style('stroke-width', 2)
-      .style('rx', 5)
+      .style('rx', 5);
 
-
-    nodeEnter
-      .append('text')
+    nodeEnter.append('text')
       .attr('dy', '.35em')
       .attr('x', 0)
       .attr('y', 0)
       .attr('text-anchor', 'middle')
       .text((d) => d.data.tag)
       .style('fill', '#1E90FF')
-      .style('font-weight', 'bold')
+      .style('font-weight', 'bold');
 
-    const nodeUpdate = nodeEnter.merge(node);
-
-    nodeUpdate
-      .transition()
-      .duration(500)
+    nodeEnter.merge(node)
+      .transition().duration(500)
       .attr('transform', (d) => `translate(${d.x},${d.y})`);
 
     node.exit()
-      .transition()
-      .duration(500)
+      .transition().duration(500)
       .attr('transform', () => `translate(${source.x},${source.y})`)
       .remove();
+  };
 
+  const updateLinks = (
+    source: d3.HierarchyPointNode<DomNode>,
+    g: d3.Selection<SVGGElement, unknown, null, undefined>,
+    links: d3.HierarchyPointLink<DomNode>[],
+    linkSelection: d3.Selection<SVGPathElement, d3.HierarchyPointLink<DomNode>, SVGGElement, unknown>
+  ) => {
     const link = linkSelection.data(links, (d) => d.target.data.id);
-
-    const linkEnter = link
-      .enter()
+    const linkEnter = link.enter()
       .append('path')
       .attr('class', 'link')
-      .attr('d', (d) => {
-        const o = { x: source.x0 ?? source.x, y: source.y0 ?? source.y };
-        return diagonal(o, o);
-      })
+      .attr('d', (d) => diagonal(source, source))
       .style('fill', 'none')
       .style('stroke', '#1E90FF')
       .style('stroke-width', 2);
 
     linkEnter.merge(link)
-      .transition()
-      .duration(500)
+      .transition().duration(500)
       .attr('d', (d) => diagonal(d.source, d.target));
 
     link.exit()
-      .transition()
-      .duration(500)
-      .attr('d', (d) => {
-        const o = { x: source.x, y: source.y };
-        return diagonal(o, o);
-      })
+      .transition().duration(500)
+      .attr('d', (d) => diagonal(source, source))
       .remove();
-
-    nodes.forEach((d) => {
-      d.x0 = d.x;
-      d.y0 = d.y;
-    });
   };
 
-  const diagonal = (s: { x: number; y: number }, d: { x: number; y: number }) => {
-    const nodeHeight = 30;
-
-    const startX = s.x;
-    const startY = s.y + nodeHeight / 2;
-
-    const endX = d.x;
-    const endY = d.y - nodeHeight / 2;
-
-    return `
-      M ${startX} ${startY}
-      C ${(startX + endX) / 2} ${startY},
-        ${(startX + endX) / 2} ${endY},
-        ${endX} ${endY}
-    `;
-  };
-
+  const diagonal = (s: { x: number; y: number }, d: { x: number; y: number }) => `
+    M ${s.x} ${s.y + 15}
+    C ${(s.x + d.x) / 2} ${s.y + 15},
+      ${(s.x + d.x) / 2} ${d.y - 15},
+      ${d.x} ${d.y - 15}
+  `;
 
   return (
     <div>

--- a/src/app/result/components/DomGraph.tsx
+++ b/src/app/result/components/DomGraph.tsx
@@ -23,10 +23,16 @@ export default function DomGraph({ data }: DomGraphProps) {
   useEffect(() => {
     if (!svgRef.current || !data) return;
 
-    const width = 800;
-    const height = 6000;
-    const treeLayout = d3.tree<DomNode>().size([width, height - 100]);
+    const treeLayout = d3.tree<DomNode>().nodeSize([80, 30]);
+
     const root = d3.hierarchy(data) as d3.HierarchyPointNode<DomNode>;
+    rootRef.current = root;
+
+    root.children?.forEach((child) => {
+      child._children = child.children;
+      child.children = undefined;
+    });
+
     const svg = d3.select(svgRef.current);
     svg.selectAll('*').remove();
 


### PR DESCRIPTION
- 첫 렌더링 시 루트 노드와 그 자식 노드까지 렌더링
- 노드를 접은 상태와 핀 상태의 가로 간격을 다르게 변경
- 노드의 모양을 rect로 변경
- 노드의 개수에 따라 svg 크기 조정
- D3 줌(Zoom) 및 스크롤 기능 추가
- 주요 기능(트리 렌더링, 줌 기능, 노드 및 링크 업데이트)을 모듈화