### PR TITLE
[FEAT] Performance metric 수집 API 추가

### DIFF
--- a/src/app/api/analyze/getPerformanceMetrics.ts
+++ b/src/app/api/analyze/getPerformanceMetrics.ts
@@ -1,0 +1,37 @@
+import { PerformanceMetrics } from "@/app/types";
+import puppeteer, { Browser } from "puppeteer";
+
+export async function getPerformanceMetrics(browser: Browser, url: string): Promise<PerformanceMetrics> {
+    const page = await browser.newPage();
+    const client = await page.target().createCDPSession();
+
+    try {
+        await page.setViewport({ width: 1280, height: 800 });
+        await page.goto(url, { waitUntil: "networkidle2" });
+
+        const nodeCount = await page.evaluate(() => document.querySelectorAll("*").length);
+
+        await client.send("Performance.enable");
+
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+
+        const performanceMetrics = await client.send("Performance.getMetrics");
+
+        const metricsMap: Record<string, number> = {};
+        for (const metric of performanceMetrics.metrics) {
+            metricsMap[metric.name] = metric.value;
+        }
+        
+        return {
+            fmp: (metricsMap["FirstMeaningfulPaint"] - metricsMap["NavigationStart"]) * 1000 || 0,
+            dcl: (metricsMap["DomContentLoaded"] - metricsMap["NavigationStart"]) * 1000 || 0,
+            layoutCount: metricsMap["LayoutCount"] || 0,
+            recalcStyleCount: metricsMap["RecalcStyleCount"] || 0,
+            scriptExecutionTime: metricsMap["ScriptDuration"] * 1000 || 0,
+            resourceCount: metricsMap["Resources"] || 0,
+            jsHeapUsedSize: metricsMap["JSHeapUsedSize"] / metricsMap["JSHeapTotalSize"] || 0,
+        };
+    } finally {
+        await page.close();
+    }
+}

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { launch } from "puppeteer";
-import { generateDomGraph } from "./generateDomGraph";
 import { AnalyzeResult } from "@/app/types";
-import { getNavigationTiming } from "./getNavigationTiming";
-import { getPerformanceMetrics } from "./getPerformanceMetrics";
+import { generateDomGraph } from "@/lib/analyze/generateDomGraph";
+import { getNavigationTiming } from "@/lib/analyze/getNavigationTiming";
+import { getPerformanceMetrics } from "@/lib/analyze/getPerformanceMetrics";
 
 
 export async function GET(req: NextRequest) {

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -3,6 +3,7 @@ import { launch } from "puppeteer";
 import { generateDomGraph } from "./generateDomGraph";
 import { AnalyzeResult } from "@/app/types";
 import { getNavigationTiming } from "./getNavigationTiming";
+import { getPerformanceMetrics } from "./getPerformanceMetrics";
 
 
 export async function GET(req: NextRequest) {
@@ -42,16 +43,19 @@ async function analyzeAll(url: string) : Promise<AnalyzeResult> {
   try {
     const domGraphPromise = generateDomGraph(browser, url);
     const navigationTimingPromise = getNavigationTiming(browser, url);
+    const performanceMetricsPromise = getPerformanceMetrics(browser, url);
 
 
-    const [domGraph, navigationTiming] = await Promise.all([
+    const [domGraph, navigationTiming, performanceMetrics] = await Promise.all([
       domGraphPromise,
-      navigationTimingPromise
+      navigationTimingPromise,
+      performanceMetricsPromise
     ]);
 
     return {
       domGraph,
-      navigationTiming
+      navigationTiming,
+      performanceMetrics
     };
   } finally {
     await browser.close();

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,6 +1,7 @@
 export interface AnalyzeResult {
   domGraph: DomNode;
   navigationTiming: NavigationTiming;
+  performanceMetrics: PerformanceMetrics;
 }
 
 export type DomNode = {
@@ -50,4 +51,14 @@ export interface EventData {
   label: string;
   start: number;
   end: number;
+}
+
+export interface PerformanceMetrics {
+  fmp: number;
+  dcl: number;
+  layoutCount: number;
+  recalcStyleCount: number;
+  scriptExecutionTime: number;
+  resourceCount: number;
+  jsHeapUsedSize: number;
 }

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,4 +1,4 @@
-export interface AnalyzeResult {
+export type AnalyzeResult = {
   domGraph: DomNode;
   navigationTiming: NavigationTiming;
   performanceMetrics: PerformanceMetrics;
@@ -11,7 +11,7 @@ export type DomNode = {
 };
 
 
-export interface NavigationTiming {
+export type NavigationTiming = {
   type: string;
   startTime: number;
   duration: number;
@@ -33,6 +33,16 @@ export interface NavigationTiming {
   loadEventEnd: number;
 }
 
+export type PerformanceMetrics = {
+  fmp: number;
+  dcl: number;
+  layoutCount: number;
+  recalcStyleCount: number;
+  scriptExecutionTime: number;
+  resourceCount: number;
+  jsHeapUsedSize: number;
+}
+
 export type TimingDataSubset = Pick<
   NavigationTiming,
   | 'domainLookupStart'
@@ -47,18 +57,10 @@ export type TimingDataSubset = Pick<
   | 'loadEventEnd'
 >;
 
-export interface EventData {
+export type EventData = {
   label: string;
   start: number;
   end: number;
 }
 
-export interface PerformanceMetrics {
-  fmp: number;
-  dcl: number;
-  layoutCount: number;
-  recalcStyleCount: number;
-  scriptExecutionTime: number;
-  resourceCount: number;
-  jsHeapUsedSize: number;
-}
+

--- a/src/lib/analyze/generateDomGraph.ts
+++ b/src/lib/analyze/generateDomGraph.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { DomNode } from "@/app/types";
 import { Browser } from "puppeteer";
 

--- a/src/lib/analyze/generateDomGraph.ts
+++ b/src/lib/analyze/generateDomGraph.ts
@@ -1,23 +1,32 @@
-"use server";
+"use server"; // Next.js 서버 환경에서 실행
 
 import { DomNode } from "@/app/types";
 import { Browser } from "puppeteer";
 
+/**
+ * 주어진 URL의 DOM 구조를 트리 형태로 분석하여 반환
+ * @param {Browser} browser - Puppeteer 브라우저 인스턴스
+ * @param {string} url - 분석할 웹페이지의 URL
+ * @returns {Promise<DomNode>} - DOM 트리 구조 객체
+ */
 export async function generateDomGraph(browser: Browser, url: string): Promise<DomNode> {
   const page = await browser.newPage();
 
   try {
     await page.goto(url, { waitUntil: "load" });
 
+    /**
+     * 브라우저 내부에서 실행되며, 현재 페이지의 DOM을 재귀적으로 탐색하여 트리 형태로 변환
+     * @returns {DomNode} - DOM 트리 구조 객체
+     */
     const domGraph: DomNode = await page.evaluate(() => {
       function buildGraph(node: HTMLElement, path = "0"): DomNode {
-        const children = Array.from(node.children).map((child, index) =>
-          buildGraph(child as HTMLElement, `${path}-${index}`)
-        );
         return {
           id: path,
           tag: node.tagName.toLowerCase(),
-          children,
+          children: Array.from(node.children).map((child, index) =>
+            buildGraph(child as HTMLElement, `${path}-${index}`)
+          ),
         };
       }
 

--- a/src/lib/analyze/getNavigationTiming.ts
+++ b/src/lib/analyze/getNavigationTiming.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { NavigationTiming } from "@/app/types";
 import { Browser } from "puppeteer";
 

--- a/src/lib/analyze/getNavigationTiming.ts
+++ b/src/lib/analyze/getNavigationTiming.ts
@@ -3,12 +3,22 @@
 import { NavigationTiming } from "@/app/types";
 import { Browser } from "puppeteer";
 
+/**
+ * 주어진 URL의 네비게이션 타이밍 데이터를 수집하여 반환
+ * @param {Browser} browser - Puppeteer 브라우저 인스턴스
+ * @param {string} url - 분석할 웹페이지의 URL
+ * @returns {Promise<NavigationTiming>} - 네비게이션 타이밍 데이터
+ */
 export async function getNavigationTiming(browser: Browser, url: string): Promise<NavigationTiming> {
   const page = await browser.newPage();
 
   try {
     await page.goto(url, { waitUntil: "load" });
 
+    /**
+     * 브라우저 내부에서 실행되며, Performance API를 이용해 네비게이션 타이밍 데이터를 수집
+     * @returns {NavigationTiming} - 수집된 네비게이션 타이밍 데이터
+     */
     const navigationTiming = await page.evaluate(() => {
       const entries = performance.getEntriesByType("navigation");
 

--- a/src/lib/analyze/getPerformanceMetrics.ts
+++ b/src/lib/analyze/getPerformanceMetrics.ts
@@ -3,6 +3,12 @@
 import { PerformanceMetrics } from "@/app/types";
 import { Browser } from "puppeteer";
 
+/**
+ * 주어진 URL의 성능 메트릭을 측정하여 반환
+ * @param {Browser} browser - Puppeteer 브라우저 인스턴스
+ * @param {string} url - 성능을 측정할 웹페이지의 URL
+ * @returns {Promise<PerformanceMetrics>} - 성능 메트릭 데이터
+ */
 export async function getPerformanceMetrics(browser: Browser, url: string): Promise<PerformanceMetrics> {
     const page = await browser.newPage();
     const client = await page.target().createCDPSession();
@@ -11,19 +17,32 @@ export async function getPerformanceMetrics(browser: Browser, url: string): Prom
         await page.setViewport({ width: 1280, height: 800 });
         await page.goto(url, { waitUntil: "networkidle2" });
 
+        /**
+         * DOM 내 전체 노드 수를 계산하여 성능 지표로 활용
+         */
         const nodeCount = await page.evaluate(() => document.querySelectorAll("*").length);
 
+        /**
+         * Chrome DevTools Protocol(CDP)을 이용하여 성능 데이터 수집 활성화
+         */
         await client.send("Performance.enable");
 
+        // 안정적인 성능 측정을 위해 5초 대기
         await new Promise((resolve) => setTimeout(resolve, 5000));
 
+        /**
+         * CDP를 통해 브라우저의 성능 메트릭 데이터 가져오기
+         */
         const performanceMetrics = await client.send("Performance.getMetrics");
 
         const metricsMap: Record<string, number> = {};
         for (const metric of performanceMetrics.metrics) {
             metricsMap[metric.name] = metric.value;
         }
-        
+
+        /**
+         * 수집된 성능 데이터를 가공하여 반환
+         */
         return {
             fmp: (metricsMap["FirstMeaningfulPaint"] - metricsMap["NavigationStart"]) * 1000 || 0,
             dcl: (metricsMap["DomContentLoaded"] - metricsMap["NavigationStart"]) * 1000 || 0,

--- a/src/lib/analyze/getPerformanceMetrics.ts
+++ b/src/lib/analyze/getPerformanceMetrics.ts
@@ -18,11 +18,6 @@ export async function getPerformanceMetrics(browser: Browser, url: string): Prom
         await page.goto(url, { waitUntil: "networkidle2" });
 
         /**
-         * DOM 내 전체 노드 수를 계산하여 성능 지표로 활용
-         */
-        const nodeCount = await page.evaluate(() => document.querySelectorAll("*").length);
-
-        /**
          * Chrome DevTools Protocol(CDP)을 이용하여 성능 데이터 수집 활성화
          */
         await client.send("Performance.enable");

--- a/src/lib/analyze/getPerformanceMetrics.ts
+++ b/src/lib/analyze/getPerformanceMetrics.ts
@@ -1,5 +1,7 @@
+"use server";
+
 import { PerformanceMetrics } from "@/app/types";
-import puppeteer, { Browser } from "puppeteer";
+import { Browser } from "puppeteer";
 
 export async function getPerformanceMetrics(browser: Browser, url: string): Promise<PerformanceMetrics> {
     const page = await browser.newPage();


### PR DESCRIPTION
1. Chrome DevTools Protocol(CDP)을 사용한 성능 데이터 수집 코드 추가
- FMP(First Meaningful Paint): 첫 번째 의미 있는 렌더링 시간(ms)
- DCL(DOMContentLoaded Event Time): DOMContentLoaded 이벤트 완료 시간(ms)
- 레이아웃 관련 데이터: layoutCount, recalcStyleCount
- 스크립트 실행 시간: scriptExecutionTime(ms)
- 리소스 개수: resourceCount
- JS Heap 사용량 비율: jsHeapUsedSize
2. 타입 일관성 개선
3. 분석 함수에 설명 주석 추가